### PR TITLE
Remove `which` as a dependency

### DIFF
--- a/lib/rvt/engine.rb
+++ b/lib/rvt/engine.rb
@@ -75,7 +75,11 @@ module RVT
         # generator, so bin/rails may not be available.
         if c.command.blank?
           local_rails = Rails.root.join('bin/rails')
-          timeout_path = `which timeout`.chomp
+          begin
+            `timeout 2>/dev/null`
+            timeout_path = 'timeout' unless $?.exitstatus == 127
+          rescue Errno::ENOENT
+          end
           timeout_suffix =
             if timeout_path.present? && c.process_timeout.present?
               "#{timeout_path} #{c.process_timeout.to_i}"


### PR DESCRIPTION
In Ruby 3, if which is not present on the system, `which timeout` will raise an Errno::ENOENT. This can be suppressed by appending 2>/dev/null to the command. The which command is not necessary as we are using the shell to find it anyway, what matters is the existence or otherwise of the timeout command. Errno::ENOENT is still caught just in case a future version of Ruby decides to change its mind.